### PR TITLE
Cast datestart as a string to use as a shelve key

### DIFF
--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -74,7 +74,7 @@ for long_dur in lowkals[bad]:
     if datestart not in bad_db:
         logger.warn('WARNING: Fewer than two kalman stars at {} for {:.1f} secs'
                     .format(datestart, long_dur['duration']))
-        bad_db[datestart] = long_dur['duration']
+        bad_db[str(datestart)] = long_dur['duration']
 bad_db.close()
 
 # Make the plot


### PR DESCRIPTION
As of skare 0.18 it looks like shelve can't use an np.string_ as a key.
Casting to a plain string seems sufficient for this shelve dictionary application.
