### PR TITLE
Increase Y plot max to 130 secs

### DIFF
--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -85,7 +85,7 @@ if np.any(recent_bad):
 x0, x1 = plt.xlim()
 dx = (x1 - x0) * 0.05
 plt.xlim(x0 - dx, x1 + dx)
-plt.ylim(-5, 100)
+plt.ylim(-5, 130)
 plt.grid()
 plt.ylabel('Duration (seconds)')
 plt.title('Duration of contiguous n_kalman <= 1')


### PR DESCRIPTION
Increase Y plot max to 130 secs.  Looks like some events with durations greater than 100 are currently omitted from the plot.  I assume the max is 30 * 4.1 secs so 130 secs should get all cases with some padding.

(I misunderstood both what the code is doing and what the max should be -Jean)