### PR TITLE
Filter to just count samples in Kalman

### DIFF
--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -37,8 +37,8 @@ def get_opt():
                         help='Output directory')
     parser.add_argument('--long-duration',
                         type=float,
-                        default=20.0,
-                        help='Threshold for long duration drop intervals (default=20 sec)')
+                        default=27.0,
+                        help='Threshold for long duration drop intervals (default=27 sec)')
     args = parser.parse_args()
     return args
 

--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -86,7 +86,7 @@ if np.any(recent_bad):
 x0, x1 = plt.xlim()
 dx = (x1 - x0) * 0.05
 plt.xlim(x0 - dx, x1 + dx)
-plt.ylim(-5, 100)
+plt.ylim(-5, 40)
 plt.grid()
 plt.ylabel('Duration (seconds)')
 plt.title('Duration of contiguous n_kalman <= 1')

--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -50,16 +50,17 @@ start = DateTime(opt.start or stop - 3 * 365)
 
 # Get the AOKALSTR data with number of kalman stars reported by OBC
 logger.info('Getting AOKALSTR between {} and {}'.format(start.date, stop.date))
-dat = fetch.Msidset(['aokalstr', 'aoacaseq'], start, stop)
+dat = fetch.Msidset(['aokalstr', 'aoacaseq', 'aopcadmd'], start, stop)
 dat.interpolate(1.025)
 last_date = DateTime(dat['aokalstr'].times[-1]).date
 
 logger.info('Finding intervals of low kalman stars')
 # Find intervals of low kalman stars
 lowkals = logical_intervals(dat['aokalstr'].times,
-                            (dat['aokalstr'].vals.astype(int) <= 1) & (dat['aoacaseq'].vals == 'KALM'),
+                            (dat['aokalstr'].vals.astype(int) <= 1)
+                            & (dat['aoacaseq'].vals == 'KALM')
+                            & (dat['aopcadmd'].vals == 'NPNT'),
                             max_gap=10.0)
-
 # Select long-duration events
 bad = lowkals['duration'] > opt.long_duration
 dt_stop = (stop.secs - DateTime(lowkals['datestart']).secs) / 86400.

--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -37,8 +37,8 @@ def get_opt():
                         help='Output directory')
     parser.add_argument('--long-duration',
                         type=float,
-                        default=60.0,
-                        help='Threshold for long duration drop intervals (default=60 sec)')
+                        default=20.0,
+                        help='Threshold for long duration drop intervals (default=20 sec)')
     args = parser.parse_args()
     return args
 

--- a/kalman_watch.py
+++ b/kalman_watch.py
@@ -46,7 +46,10 @@ def get_opt():
 opt = get_opt()
 
 stop = DateTime(opt.stop)
-start = DateTime(opt.start or stop - 3 * 365)
+
+# Default start is beginning of calendar year 3 years ago
+start = DateTime(opt.start or DateTime(int(DateTime().frac_year - 3), format='frac_year').date)
+
 
 # Get the AOKALSTR data with number of kalman stars reported by OBC
 logger.info('Getting AOKALSTR between {} and {}'.format(start.date, stop.date))


### PR DESCRIPTION
This is just an idea to only count samples in Kalman that meet the AOKALSTR <= 1 test when determining intervals with low stars.

It makes more sense to me and also seems to result in fewer false positives (that were later filtered in kalman_watch by ignoring intervals > 120 seconds).