### PR TITLE
Remove maude from fetch data source

### DIFF
--- a/kalman_watch/low_kalman_mon.py
+++ b/kalman_watch/low_kalman_mon.py
@@ -151,7 +151,7 @@ def get_lowkals_new(
     # Warn in processing for long duration drop intervals
     long_mask = lowkals["duration"] > opt.long_duration
     for lowkal in lowkals[long_mask]:
-        logger.warn(
+        logger.warning(
             f"WARNING: Fewer than two kalman stars at {lowkal['datestart']} "
             f"for {lowkal['duration']:.1f} secs"
         )

--- a/kalman_watch/low_kalman_mon.py
+++ b/kalman_watch/low_kalman_mon.py
@@ -116,12 +116,7 @@ def get_lowkals_new(
     # Get the AOKALSTR data with number of kalman stars reported by OBC.
     logger.info(f"Getting telemetry between {start} and {stop}")
 
-    # WARNING: this is a trap I fell into! This needs fixing. Grabbing data
-    # from MAUDE like this might result in data gaps during comm.
-    with fetch.data_source("cxc", "maude allow_subset=False"):
-        dat = fetch.Msidset(
-            ["aokalstr", "aoacaseq", "aopcadmd", "cobsrqid"], start, stop
-        )
+    dat = fetch.Msidset(["aokalstr", "aoacaseq", "aopcadmd", "cobsrqid"], start, stop)
     dat.interpolate(1.025)
 
     if len(dat.times) < 300:


### PR DESCRIPTION
## Description
The low kalman event on day 2022:301 did not show up in kalman_watch3, but we did see it in the legacy kalman_watch (py2) processing. I suspect this was a case that had been warned about in the comments where recent real-time data in MAUDE hides the fact that there is a large data gap in the back-orbit telemetry.

This PR goes back to using only CXC telemetry which has more latency but is reliable.

### Unit testing
None

### Functional testing
Edited a local copy of `low_kalman_events.ecsv` to have a start date before the recent 2022:301 events:
```
# ---
# datatype:
# - {name: datestart, datatype: string}
# - {name: duration, datatype: float64}
# - {name: obsid, datatype: int64}
# - {name: comment, datatype: string}
# meta: !!omap
# - {date_telem_last: '2022:300:12:15:48.943'}
# schema: astropy-2.0
datestart duration obsid comment
2022:231:18:42:31.755 31.8 45317 "CTU reset => NSM"
2022:224:02:18:45.837 31.8 45339 "BSH recovery"
2022:224:02:17:32.037 32.8 45339 "many repeats..."
...
```
Then in the git repo from this branch:
```
ska3-kady$ python -m kalman_watch.low_kalman_mon --stop 2022:303 --data-dir=.
2022-10-31 06:20:44,624 get_lowkals_new: Getting telemetry between 2022:300:12:15:48.943 and 2022:303:00:00:00.000
2022-10-31 06:20:44,890 get_lowkals_new: Finding intervals of low kalman stars
2022-10-31 06:20:44,944 get_lowkals_new: WARNING: Fewer than two kalman stars at 2022:301:09:41:48.103 for 31.8 secs
2022-10-31 06:20:44,944 get_lowkals_new: WARNING: Fewer than two kalman stars at 2022:301:09:43:42.903 for 31.8 secs
2022-10-31 06:20:44,946 get_lowkals_new: Last telemetry date: 2022:302:23:59:58.790
2022-10-31 06:20:44,946 get_lowkals_new: Found 2 new low kalman events
2022-10-31 06:20:44,951 main: Updating events file low_kalman_events.ecsv
2022-10-31 06:20:45,147 make_web_page: Writing HTML to index.html
```
With a new data file:
```
# %ECSV 1.0
# ---
# datatype:
# - {name: datestart, datatype: string}
# - {name: duration, datatype: float64}
# - {name: obsid, datatype: int64}
# - {name: comment, datatype: string}
# meta: !!omap
# - {date_telem_last: '2022:302:23:59:58.793'}
# schema: astropy-2.0
datestart duration obsid comment
2022:301:09:43:42.906 31.8 27520 ""
2022:301:09:41:48.106 31.8 27520 ""
2022:231:18:42:31.755 31.8 45317 "CTU reset => NSM"
2022:224:02:18:45.837 31.8 45339 "BSH recovery"
2022:224:02:17:32.037 32.8 45339 "many repeats..."
...
```

