### PR TITLE
Fix task schedule alert email address

### DIFF
--- a/kalman_watch/task_schedule.cfg
+++ b/kalman_watch/task_schedule.cfg
@@ -35,7 +35,7 @@ alert       aca@cfa.harvard.edu
       cron * * * * *
       check_cron * * * * *
       exec kalman_watch_low_kalman_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
-      exec kalman_watch_kalman_perigee_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3 --email=aca_alert@cfa.harvard.edu --make-html
+      exec kalman_watch_kalman_perigee_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3 --email=aca_alert\@cfa.harvard.edu --make-html
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
## Description

This fixes a mistake in the email address in the task schedule specification by escaping the `@cfa`. This follows the example here: https://github.com/sot/fss_check/commit/c674bf36c573abac1d661c814dd5f4ca4d8d1c0a.

## Testing

None for this change, but the mailing process is the same code as in `fss_check` and this has successfully sent an alert email in production.