### PR TITLE
Composite plot with perigee kalman drops per minute: NPNT and NMAN (mon win) data

### DIFF
--- a/kalman_watch/index_kalman_perigee_list.html
+++ b/kalman_watch/index_kalman_perigee_list.html
@@ -26,9 +26,7 @@
 </head>
 
 <body>
-    {% if prev %} <a href="{{prev}}/index.html">Previous</a>{% endif %}
-    {% if index %} <a href="{{index}}/index.html">Index</a>{% endif %}
-    {% if next %} <a href="{{next}}/index.html">Next</a>{% endif %}
+    <a href="../index.html">Kalman watch home</a>
     <h1>Perigee Kalman index page: {{description}}</h1>
     <table>
         <tr>

--- a/kalman_watch/index_low_kalman_template.html
+++ b/kalman_watch/index_low_kalman_template.html
@@ -37,7 +37,7 @@
 
     For a per-perigee view of Kalman drops see the  <a href="perigees/index.html">Perigee Kalman watch</a> page.
 
-    <img src="mon_win_kalman_drops_-45d_0d.png">
+    <img src="mon_win_kalman_drops_-45d_-1d.png">
 
     <h3>Kalman drop intervals (valid through {{last_date}})</h3>
 

--- a/kalman_watch/index_low_kalman_template.html
+++ b/kalman_watch/index_low_kalman_template.html
@@ -33,9 +33,13 @@
 
     <h2> Kalman star watch </h2>
 
-    See also <a href="perigees/index.html">Perigee Kalman watch</a>.
+    <h3> Kalman drops through perigee </h3>
 
-    <h3> Summary </h3>
+    For a per-perigee view of Kalman drops see the  <a href="perigees/index.html">Perigee Kalman watch</a> page.
+
+    <img src="mon_win_kalman_drops_-45d_0d.png">
+
+    <h3>Kalman drop intervals (valid through {{last_date}})</h3>
 
     <p>
         The plot below shows intervals where the number of Kalman stars
@@ -43,8 +47,6 @@
         (AOKALSTR) was zero or one for at least four updates. Intervals
         in the last 30 days are plotted in orange.
     </p>
-
-    <h3>Kalman drop intervals (valid through {{last_date}})</h3>
 
     {{plot_html}}
 

--- a/kalman_watch/index_low_kalman_template.html
+++ b/kalman_watch/index_low_kalman_template.html
@@ -37,7 +37,7 @@
 
     For a per-perigee view of Kalman drops see the  <a href="perigees/index.html">Perigee Kalman watch</a> page.
 
-    <img src="mon_win_kalman_drops_-45d_-1d.png">
+    <img src="mon_win_kalman_drops_-45d_-1d.png" width="1000">
 
     <h3>Kalman drop intervals (valid through {{last_date}})</h3>
 

--- a/kalman_watch/kalman_perigee_mon.py
+++ b/kalman_watch/kalman_perigee_mon.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Watch Kalman star data during perigee passages.
 """
 

--- a/kalman_watch/kalman_perigee_mon.py
+++ b/kalman_watch/kalman_perigee_mon.py
@@ -326,7 +326,7 @@ def get_index_html_year(stats_all, year):
     # Strip out the year/ from dirname since we are already in the year/ dir
     stats_year["dirname"] = [dirname[5:] for dirname in stats_year["dirname"]]
     prev = f"../{year - 1}" if (year - 1) in years_unique else None
-    index = f"../"
+    index = "../"
     next = f"../{year + 1}" if (year + 1) in years_unique else None
     description = f"{year}"
     html = get_index_list_page(
@@ -387,7 +387,7 @@ def get_index_list_page(
 
 
 def send_process_mail(opt, evts_perigee):
-    subject = f"kalman_watch: long drop interval(s)"
+    subject = "kalman_watch: long drop interval(s)"
     lines = ["Long drop interval(s) found for the following perigee events:"]
     for evt in evts_perigee:
         if len(evt.low_kalmans) > 0:

--- a/kalman_watch/low_kalman_mon.py
+++ b/kalman_watch/low_kalman_mon.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Process telemetry and find intervals of low Kalman stars.
 
 - Intervals are stored in <data_dir>/low_kalman_events.ecsv.

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -133,6 +133,10 @@ def get_manvrs_perigee(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
     perigee_dates = cmds[cmds["event_type"] == "EPERIGEE"]["date"]
     pcad_mode = fetch.Msid("aopcadmd", start, stop)
 
+    # TODO: with the "intervals" refactor WIP this could be done more nicely by taking
+    # the intersection of the maneuvers and the Earth block intervals. Instead here we
+    # stub in a 3rd state "EART" for Earth block intervals and report every interval
+    # even though almost all of them are not during a perigee maneuver.
     logger.info(f"Getting intervals of Earth blocks from {start.date} to {stop.date}")
     blocks = get_earth_blocks(start, stop)
     for block in blocks:
@@ -154,7 +158,6 @@ def get_manvrs_perigee(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
         manvrs_perigee.append(manvrs[ok])
 
     manvrs_perigee = vstack(manvrs_perigee)
-
     return manvrs_perigee
 
 

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -1,0 +1,301 @@
+# # Perigee monitor window data and kalman drops
+#
+# This notebook examines the monitor window data for the first handful of perigees after
+# the start of monitor windows during maneuvers.
+#
+# It also massages the data into an effective number of kalman drops per minute, matching
+# roughly the same quantity which has been shown in the kalman drops evolution analysis.
+# The data are plotted with the same function as in kalman-drops-perigee-evolution.ipynb.
+
+import argparse
+import functools
+import pickle
+from pathlib import Path
+
+import astropy.units as u
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.style
+import numpy as np
+import scipy.signal
+from astropy.table import Table, vstack
+from chandra_aca.maude_decom import get_aca_images
+from chandra_aca.transform import mag_to_count_rate
+from cheta import fetch
+from cheta.utils import logical_intervals
+from cxotime import CxoTime, date2secs
+from kadi.commands import get_cmds, get_observations, get_starcats
+from ska_helpers.logging import basic_logger
+
+from kalman_watch import __version__
+
+matplotlib.use("Agg")
+matplotlib.style.use("bmh")
+
+LOGGER = basic_logger(__name__, level="INFO")
+
+
+EARTH_BLOCKS = [
+    ("2023:297:12:23:00", "2023:297:12:48:37"),
+    ("2023:300:03:49:00", "2023:300:04:16:40"),
+]
+
+
+def get_opt() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Monitor window perigee data {}".format(__version__)
+    )
+    parser.add_argument("--stop", type=str, help="Stop date (default=NOW)")
+    parser.add_argument(
+        "--lookback", type=float, default=14, help="Lookback time (days, default=14)"
+    )
+    parser.add_argument("--data-dir", type=str, default=".", help="Data directory")
+    return parser
+
+
+def get_manvrs_perigee(start, stop):
+    """Get maneuvers that are entirely within 40 minutes of perigee.
+
+    This is used to select the monitor window data to compute the number of kalman drops
+    per minute during perigee.
+
+    Returns
+    -------
+    manvrs_perigee : Table
+        Table of intervals of maneuvers that are entirely within 40 minutes of perigee.
+    """
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+    LOGGER.info(f"Getting maneuvers from {start.date} to {stop.date}")
+
+    cmds = get_cmds(start, stop)
+
+    perigee_dates = cmds[cmds["event_type"] == "EPERIGEE"]["date"]
+
+    with fetch.data_source("cxc", "maude"):
+        pcad_mode = fetch.Msid("aopcadmd", start, stop)
+
+    for block_start, block_stop in EARTH_BLOCKS:
+        idx0, idx1 = pcad_mode.times.searchsorted(
+            [date2secs(block_start), date2secs(block_stop)]
+        )
+        pcad_mode.vals[idx0:idx1] = "EART"
+
+    manvrs = logical_intervals(pcad_mode.times, pcad_mode.vals == "NMAN")
+
+    # Get maneuvers that are entirely within 40 minutes of perigee
+    manvrs_perigee = []
+    for perigee_date in CxoTime(perigee_dates):
+        ok = (np.abs(manvrs["tstart"] - perigee_date.secs) < 40 * 60) & (
+            np.abs(manvrs["tstop"] - perigee_date.secs) < 40 * 60
+        )
+        manvrs_perigee.append(manvrs[ok])
+
+    manvrs_perigee = vstack(manvrs_perigee)
+
+    return manvrs_perigee
+
+
+def get_aca_images_cached(start, stop):
+    LOGGER.info(f"Getting ACA images from {start.date} to {stop.date}")
+    datestart = CxoTime(start).date
+    datestop = CxoTime(stop).date
+    cache_dir = Path("data")
+    cache_dir.mkdir(exist_ok=True)
+    cache = cache_dir / f"aca_imgs_{datestart}_{datestop}.fits.gz"
+    if cache.exists():
+        return Table.read(cache)
+    else:
+        imgs = get_aca_images(datestart, datestop)
+        imgs.write(cache)
+        return imgs
+
+
+def process_imgs(imgs, slot):
+    # Select MON data for this slot
+    imgs_slot = imgs[(imgs["IMGNUM"] == slot) & (imgs["IMGFUNC"] == 2)]
+    for name in imgs_slot.colnames:
+        if hasattr(imgs_slot[name], "mask"):
+            imgs_slot[name] = np.array(imgs_slot[name])
+
+    # Calibrate, compute background and subtract background
+    imgs_slot["img"] = imgs_slot["IMG"].data * 5.0 / 1.7  # e-/s, and get rid of mask
+    imgs_slot["bgd"] = np.zeros_like(imgs_slot["img"])
+    for ii in range(8):
+        for jj in range(8):
+            imgs_slot["bgd"][:, ii, jj] = scipy.signal.medfilt(
+                imgs_slot["img"][:, ii, jj], 5
+            )
+    imgs_slot["img_corr"] = imgs_slot["img"] - imgs_slot["bgd"]
+    imgs_slot["img_sum"] = np.sum(imgs_slot["img_corr"], axis=(1, 2))
+
+    # Box median filter doesn't get edges right
+    imgs_slot = imgs_slot[3:-3]
+
+    return imgs_slot
+
+
+def get_nearest_perigee_date(date) -> CxoTime:
+    date = CxoTime(date)
+    cmds = get_cmds(date - 3 * u.d, date + 3 * u.d, event_type="EPERIGEE")
+    idx = np.argmin(np.abs(cmds["time"] - date.secs))
+    return CxoTime(cmds["date"][idx])
+
+
+@functools.lru_cache()
+def get_ir_thresholds(start, stop):
+    LOGGER.info(f"Getting IR thresholds from {start} to {stop}")
+    obss = get_observations(start, stop)
+    thresholds_list = []
+    for obs in obss:
+        if obs["obsid"] > 38000:
+            scs = get_starcats(obsid=obs["obsid"])
+            if len(scs) == 1:
+                stars = scs[0]
+                ok = np.isin(stars["type"], ("BOT", "GUI"))
+                mags = stars["mag"][ok]
+                thresholds = np.maximum(350, mag_to_count_rate(mags) / 16)
+                thresholds_list.append(thresholds)
+
+    out = np.concatenate(thresholds_list)
+    return out
+
+
+def get_hits(mon):
+    ir_thresholds_iter = get_ir_thresholds("2023:100", "2023:200")
+
+    img_sum = mon["imgs"]["img_sum"]
+    img_idxs = np.where(img_sum > 500)[0]
+    img_sums = img_sum[img_idxs]
+    img_maxs = np.max(mon["imgs"]["img_corr"][img_idxs], axis=(1, 2))
+    hit_pixels = img_sums / img_maxs
+
+    hits = []
+    for img_idx, img_sum, img_max, hit_pixel, threshold in zip(
+        img_idxs, img_sums, img_maxs, hit_pixels, ir_thresholds_iter
+    ):
+        hit = {
+            "time": mon["imgs"]["TIME"][img_idx],
+            "dt_min": mon["imgs"]["dt_min"][img_idx],
+            "slot": mon["imgs"]["IMGNUM"][img_idx],
+            "ir_flag": img_sum > threshold,
+            "img_idx": img_idx,
+            "sum": img_sum,
+            "max": img_max,
+            "pixels": hit_pixel,
+        }
+        hits.append(hit)
+    hits = Table(hits)
+    hits["hit_idx"] = np.arange(len(hits))
+    return hits
+
+
+def get_mon_dataset(start, stop):
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+    start.format = "date"
+    stop.format = "date"
+    LOGGER.info(f"Getting MON data from {start.date} to {stop.date}")
+    imgs = get_aca_images_cached(start, stop)
+
+    # Create a dataset of MON data for this slot
+    mon = {}
+    mons = []
+    for slot in range(8):
+        mons.append(process_imgs(imgs, slot))
+    mon["imgs"] = vstack(mons)
+    mon["imgs"].sort("TIME")
+    mon["imgs"]["img_idx"] = np.arange(len(mon["imgs"]))
+    mon["perigee_date"] = get_nearest_perigee_date(imgs["TIME"][len(imgs) // 2])
+    mon["imgs"]["dt_min"] = (mon["imgs"]["TIME"] - mon["perigee_date"].secs) / 60
+    mon["start"] = start
+    mon["stop"] = stop
+
+    mon["hits"] = get_hits(mon)
+
+    return mon
+
+
+def get_kalman_drops_per_minute(mon):
+    # Get the number of drops per "minute", where a "minute" is really 60 * 1.025
+    # seconds, or 1.025 minutes. This matches what is done in
+    # kalman-drops-perigee-evolution.ipynb.
+    bins = np.arange(-30, 31, 1.025)
+    kalman_drops = []
+    dt_mins = []
+    for dt_min0, dt_min1 in zip(bins[:-1], bins[1:]):
+        ok = (mon["hits"]["dt_min"] >= dt_min0) & (mon["hits"]["dt_min"] < dt_min1)
+        n_drops = np.sum(mon["hits"][ok]["ir_flag"])
+        if n_drops > 0:
+            kalman_drops.append(n_drops)
+            dt_mins.append((dt_min0 + dt_min1) / 2)
+
+    return np.array(dt_mins), np.array(kalman_drops)
+
+
+# Copied from kalman-drops-perigee-evolution.ipynb but added `label` argument
+def plot_kalman_drops(kalman_drops_data, ax, alpha=1.0, title=None, label=None):
+    _, _, times, n_drops, colors = kalman_drops_data
+    scat = ax.scatter(
+        times / 60,
+        n_drops.clip(None, 160),
+        s=10,
+        c=colors,
+        alpha=alpha,
+        label=label,
+    )
+    # set major ticks every 10 minutes
+    ax.xaxis.set_major_locator(plt.MultipleLocator(10))
+    ax.set_xlabel("Time from perigee (minutes)")
+    return scat
+
+
+def get_kalman_drops_data(mon, idx):
+    """Get kalman_drops data in the peculiar form for plot_kalman_drops"""
+    dt_mins, kalman_drops = get_kalman_drops_per_minute(mon)
+    color = ["r", "m", "b", "g", "k"][idx % 5]
+    colors = [color] * len(dt_mins)
+    times = np.array(dt_mins) * 60
+    kalman_drops_data = (mon["start"], mon["stop"], times, kalman_drops, colors)
+    return kalman_drops_data
+
+
+def plot_kalman_drops_all(kalman_drops_data_list, savefig=None):
+    fig, ax = plt.subplots(1, 1, figsize=(12, 3.5))
+    for kalman_drops_data in kalman_drops_data_list:
+        plot_kalman_drops(
+            kalman_drops_data,
+            ax,
+            alpha=1.0,
+        )
+    ax.set_title("Kalman drops per minute")
+
+    if savefig:
+        fig.savefig(savefig)
+
+
+def main():
+    opt = get_opt().parse_args()
+    stop = CxoTime(opt.stop)
+    start = stop - opt.lookback * u.d
+
+    manvrs_perigee = get_manvrs_perigee(start, stop)
+
+    mons = []
+    for manvr in manvrs_perigee:
+        mon = get_mon_dataset(manvr["datestart"], manvr["datestop"])
+        mons.append(mon)
+
+    kalman_drops_data_list = []
+    for idx, mon in enumerate(mons):
+        kalman_drops_data = get_kalman_drops_data(mon, idx)
+        kalman_drops_data_list.append(kalman_drops_data)
+
+    outfile = Path(opt.data_dir) / "mon_win_kalman_drops.png"
+    plot_kalman_drops_all(kalman_drops_data_list, savefig=outfile)
+
+    # pickle.dump(kalman_drops_data_list, open("mon_win_kalman_drops_data.pkl", "wb"))
+
+
+if __name__ == "__main__":
+    main()

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -692,7 +692,7 @@ def plot_mon_win_and_aokalstr_composite(
     fig.tight_layout()
 
     if outfile:
-        fig.savefig(outfile)
+        fig.savefig(outfile, dpi=200)
 
 
 def cxotime_reldate(date):

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -13,22 +13,25 @@ cache the MAUDE images in the ``<data_dir>/aca_imgs_cache/`` directory.
 
 import argparse
 import functools
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias
 
+os.environ["MPLBACKEND"] = "Agg"
+
 import astropy.units as u
 import kadi.events
-import matplotlib
+import matplotlib.collections
 import matplotlib.pyplot as plt
 import matplotlib.style
 import numpy as np
 import scipy.signal
 from astropy.table import Table, vstack
 from chandra_aca.maude_decom import get_aca_images
-from chandra_aca.transform import mag_to_count_rate
 from chandra_aca.planets import get_earth_blocks
+from chandra_aca.transform import mag_to_count_rate
 from cheta import fetch
 from cheta.utils import logical_intervals
 from cxotime import CxoTime, CxoTimeLike
@@ -762,5 +765,4 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    matplotlib.use("Agg")
     main()

--- a/kalman_watch/task_schedule.cfg
+++ b/kalman_watch/task_schedule.cfg
@@ -34,9 +34,9 @@ alert       aca@cfa.harvard.edu
 <task kalman_watch>
       cron * * * * *
       check_cron * * * * *
-      exec kalman_watch_monitor_win_perigee --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
       exec kalman_watch_low_kalman_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
       exec kalman_watch_kalman_perigee_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3 --email=aca_alert\@cfa.harvard.edu --make-html
+      exec kalman_watch_monitor_win_perigee --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
       <check>
         <error>
           #    File           Expression

--- a/kalman_watch/task_schedule.cfg
+++ b/kalman_watch/task_schedule.cfg
@@ -34,6 +34,7 @@ alert       aca@cfa.harvard.edu
 <task kalman_watch>
       cron * * * * *
       check_cron * * * * *
+      exec kalman_watch_monitor_win_perigee --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
       exec kalman_watch_low_kalman_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3
       exec kalman_watch_kalman_perigee_mon --data-dir=$ENV{SKA}/www/ASPECT/kalman_watch3 --email=aca_alert\@cfa.harvard.edu --make-html
       <check>

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ except ImportError:
 
 entry_points = {
     "console_scripts": [
+        "kalman_watch_monitor_win_perigee = kalman_watch.monitor_win_perigee:main",
         "kalman_watch_low_kalman_mon = kalman_watch.low_kalman_mon:main",
         "kalman_watch_kalman_perigee_mon = kalman_watch.kalman_perigee_mon:main",
     ]


### PR DESCRIPTION
## Description
This adds a new trending script to generate a composite plot with perigee kalman drops per minute in two cases of PCAD mode: 
- NPNT using AOKALSTR data from the OBC
- NMAN using monitor window data and a statistically-correct simulation of ACA PEA ionizing radiation flags

## Requires
This requires https://github.com/sot/chandra_aca/pull/164

## Functional testing
### Running from 2023:290 to 2023:310
This includes perigee passes with no monitor window data (before we started adding the commanding) and passes with Earth blocks. This is evident in the run logs.

```
➜  kalman_watch git:(monitor-win-perigee) ✗ python -m kalman_watch.monitor_win_perigee --data-dir=test --start="2023:290" --stop="2023:310"
2024-01-02 06:06:44,761 get_manvrs_perigee: Getting maneuvers from 2023:290:00:00:00.000 to 2023:310:00:00:00.000
2024-01-02 06:06:45,852 get_manvrs_perigee: Getting intervals of Earth blocks from 2023:290:00:00:00.000 to 2023:310:00:00:00.000
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:297:12:21:06.304 to 2023:297:12:49:59.579
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:298:20:54:50.436 to 2023:298:20:59:39.486
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:300:03:47:33.744 to 2023:300:04:16:31.119
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:300:17:11:19.997 to 2023:300:17:17:38.222
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:301:00:38:35.523 to 2023:301:00:43:43.023
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:305:21:35:24.050 to 2023:305:21:40:39.750
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:307:06:10:18.908 to 2023:307:06:15:29.483
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:309:03:33:42.369 to 2023:309:03:39:28.819
2024-01-02 06:06:47,143 get_manvrs_perigee:  Excluding Earth block from 2023:309:11:26:53.845 to 2023:309:11:31:18.295
2024-01-02 06:06:47,164 get_mon_dataset: Getting MON data from 2023:292:05:04:00.024 to 2023:292:05:59:55.874
2024-01-02 06:06:47,165 get_aca_images_cached: Getting ACA images from 2023:292:05:04:00.024 to 2023:292:05:59:55.874
2024-01-02 06:06:47,228 get_mon_dataset: Not enough images for slot 0 found 0)
2024-01-02 06:06:47,230 get_mon_dataset: Not enough images for slot 1 found 0)
2024-01-02 06:06:47,231 get_mon_dataset: Not enough images for slot 2 found 0)
2024-01-02 06:06:47,233 get_mon_dataset: Not enough images for slot 3 found 0)
2024-01-02 06:06:47,235 get_mon_dataset: Not enough images for slot 4 found 0)
2024-01-02 06:06:47,236 get_mon_dataset: Not enough images for slot 5 found 0)
2024-01-02 06:06:47,238 get_mon_dataset: Not enough images for slot 6 found 0)
2024-01-02 06:06:47,240 get_mon_dataset: Not enough images for slot 7 found 0)
2024-01-02 06:06:47,240 main: No image data between 2023:292:05:04:00.024 and 2023:292:05:59:55.874
2024-01-02 06:06:47,240 get_mon_dataset: Getting MON data from 2023:294:20:31:00.264 to 2023:294:21:26:56.114
2024-01-02 06:06:47,240 get_aca_images_cached: Getting ACA images from 2023:294:20:31:00.264 to 2023:294:21:26:56.114
2024-01-02 06:06:47,297 get_mon_dataset: Not enough images for slot 0 found 0)
2024-01-02 06:06:47,298 get_mon_dataset: Not enough images for slot 1 found 0)
2024-01-02 06:06:47,300 get_mon_dataset: Not enough images for slot 2 found 0)
2024-01-02 06:06:47,302 get_mon_dataset: Not enough images for slot 3 found 0)
2024-01-02 06:06:47,303 get_mon_dataset: Not enough images for slot 4 found 0)
2024-01-02 06:06:47,305 get_mon_dataset: Not enough images for slot 5 found 0)
2024-01-02 06:06:47,306 get_mon_dataset: Not enough images for slot 6 found 0)
2024-01-02 06:06:47,308 get_mon_dataset: Not enough images for slot 7 found 0)
2024-01-02 06:06:47,308 main: No image data between 2023:294:20:31:00.264 and 2023:294:21:26:56.114
2024-01-02 06:06:47,309 get_mon_dataset: Getting MON data from 2023:297:11:58:59.954 to 2023:297:12:21:06.304
2024-01-02 06:06:47,309 get_aca_images_cached: Getting ACA images from 2023:297:11:58:59.954 to 2023:297:12:21:06.304
2024-01-02 06:06:47,459 get_ir_thresholds: Getting IR thresholds from 2023:100 to 2023:200
2024-01-02 06:06:50,885 get_mon_dataset: Getting MON data from 2023:297:12:49:59.579 to 2023:297:12:51:55.404
2024-01-02 06:06:50,885 get_aca_images_cached: Getting ACA images from 2023:297:12:49:59.579 to 2023:297:12:51:55.404
2024-01-02 06:06:50,995 get_mon_dataset: Getting MON data from 2023:300:03:26:00.193 to 2023:300:03:47:33.744
2024-01-02 06:06:50,995 get_aca_images_cached: Getting ACA images from 2023:300:03:26:00.193 to 2023:300:03:47:33.744
2024-01-02 06:06:51,143 get_mon_dataset: Getting MON data from 2023:300:04:16:31.119 to 2023:300:04:18:55.644
2024-01-02 06:06:51,143 get_aca_images_cached: Getting ACA images from 2023:300:04:16:31.119 to 2023:300:04:18:55.644
2024-01-02 06:06:51,255 get_mon_dataset: Getting MON data from 2023:302:18:58:35.608 to 2023:302:19:54:26.333
2024-01-02 06:06:51,255 get_aca_images_cached: Getting ACA images from 2023:302:18:58:35.608 to 2023:302:19:54:26.333
2024-01-02 06:06:51,472 get_mon_dataset: Getting MON data from 2023:305:10:26:59.898 to 2023:305:11:22:50.623
2024-01-02 06:06:51,472 get_aca_images_cached: Getting ACA images from 2023:305:10:26:59.898 to 2023:305:11:22:50.623
2024-01-02 06:06:51,752 get_mon_dataset: Getting MON data from 2023:308:01:55:35.463 to 2023:308:02:51:26.188
2024-01-02 06:06:51,752 get_aca_images_cached: Getting ACA images from 2023:308:01:55:35.463 to 2023:308:02:51:26.188
2024-01-02 06:06:52,393 clean_aca_images_cache: Cleaning ACA images cache to keep most recent 30 files
```

<img width="718" alt="image" src="https://github.com/sot/kalman_watch/assets/348089/84bea206-4975-4554-a8e3-cd69254a8c80">

### HEAD (linux)

On HEAD in ska3 2023.9 in this branch
```
cd ~/git/kalman_watch
rsync -av /proj/sot/ska/www/ASPECT/kalman_watch3 test
# Remove 2010-2022 directories in test/perigees for space
# chandra_aca repo checked out at https://github.com/sot/chandra_aca/pull/164
export PYTHONPATH=/home/aldcroft/git/chandra_aca

# These effectively replicate task_schedule.cfg
python -m kalman_watch.low_kalman_mon --data-dir=test
python -m kalman_watch.kalman_perigee_mon --data-dir=test
python -m kalman_watch.kalman_perigee_mon --data-dir=test --make-html
python -m kalman_watch.monitor_win_perigee --data-dir=test

cp -rp test ~/ska/www/ASPECT/kalman_watch3/dev
```
Results at https://cxc.cfa.harvard.edu/mta/ASPECT/kalman_watch3/dev/

### Install testing

Using `python setup.py install ..` in a test environment, confirmed that this installs an executable `kalman_watch_monitor_win_perigee` that is functional (by running with `--help`).