### PR TITLE
Plot IR flag fraction in monitor_win_perigee + style improvements

### DIFF
--- a/kalman_watch/kalman_perigee_mon.py
+++ b/kalman_watch/kalman_perigee_mon.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Watch Kalman star data during perigee passages.
-"""
-
+"""Watch Kalman star data during perigee passages."""
 
 import argparse
 import calendar
@@ -291,10 +289,7 @@ def get_stats(evts_perigee) -> Table:
     :returns: Table
         Table of kalman perigee stats
     """
-    rows = []
-
-    for evt in reversed(evts_perigee):
-        rows.append(evt.info)
+    rows = [evt.info for evt in reversed(evts_perigee)]
 
     out = Table(rows=rows)
     return out
@@ -352,7 +347,7 @@ def get_index_html_recent(stats_all):
     html = get_index_list_page(
         template,
         stats_recent,
-        years=reversed(sorted(set(years_all))),
+        years=sorted(set(years_all), reverse=True),
         description=description,
     )
     return html
@@ -389,9 +384,11 @@ def get_index_list_page(
 def send_process_mail(opt, evts_perigee):
     subject = "kalman_watch: long drop interval(s)"
     lines = ["Long drop interval(s) found for the following perigee events:"]
-    for evt in evts_perigee:
-        if len(evt.low_kalmans) > 0:
-            lines.append(f"{evt.dirname} {evt.perigee.date}")
+    lines.extend(
+        f"{evt.dirname} {evt.perigee.date}"
+        for evt in evts_perigee
+        if len(evt.low_kalmans) > 0
+    )
     text = "\n".join(lines)
     send_mail(LOGGER, opt, subject, text, __file__)
 
@@ -699,9 +696,7 @@ class EventPerigee:
         perigee_times = perigee_times.round(1)
         aokalstr = self.data["aokalstr"]
 
-        fig = make_subplots(
-            rows=3, cols=1, shared_xaxes=True, vertical_spacing=0.1
-        )  # type: pgo.FigureWidget
+        fig = make_subplots(rows=3, cols=1, shared_xaxes=True, vertical_spacing=0.1)  # type: pgo.FigureWidget
 
         for obs, color in zip(self.obss, cycle(COLOR_CYCLE)):
             obs_tstart_rel = CxoTime(obs["obs_start"]).secs - self.perigee.cxcsec

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -89,6 +89,11 @@ def get_opt() -> argparse.ArgumentParser:
         help="Stop date for sampling guide stars for IR thresholds",
     )
     parser.add_argument(
+        "--skip-mon",
+        action="store_true",
+        help="Skip monitor window data (mostly for testing)",
+    )
+    parser.add_argument(
         "--n-cache",
         type=int,
         default=30,
@@ -788,7 +793,7 @@ def main(args=None):
     stop = cxotime_reldate(opt.stop)
 
     # Intervals of NMAN within 40 minutes of perigee
-    manvrs_perigee = get_manvrs_perigee(start, stop)
+    manvrs_perigee = [] if opt.skip_mon else get_manvrs_perigee(start, stop)
 
     # Get list of monitor window data for each perigee maneuver
     mons = []

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -1,14 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Perigee monitor window data and kalman drops
+"""IR flag fraction from perigee monitor window data (NMAN) and ACA telemetry (NPNT).
 
 Generate a trending plot which combines the perigee monitor window data during NMAN with
-the kalman drops data (from AOKALSTR) during NPNT. This is used to evaluate the
+the IR flag data (from AOACIIR<n>) during NPNT. This is used to evaluate the
 evolution of the high ionizing radiation (IR) zone during perigee.
 
 This is normally run as a script which by default generates a plot
 ``<data_dir>/mon_win_kalman_drops_-45d_-1d.png`` in the current directory. It will also
 cache the MAUDE images in the ``<data_dir>/aca_imgs_cache/`` directory.
+
+NOTE: This script was originally written using AOKALSTR telemetry as a proxy for the IR
+flag data. This was later replaced with the more direct AOACIIR<n> telemetry. In many
+places there are references to Kalman drops. Generally speaking that should be taken as
+a synonym for the IR flag fraction.
 """
 
 import argparse
@@ -490,7 +495,7 @@ def get_kalman_drops_per_minute(mon: MonDataSet) -> tuple[np.ndarray, np.ndarray
     kalman_drops : np.ndarray
         Array of number of kalman drops per minute scaled
     """
-    bins = np.arange(-30, 31, 1.025)
+    bins = np.arange(-100, 100, 1.025)
     kalman_drops = []
     dt_mins = []
     for dt_min0, dt_min1 in zip(bins[:-1], bins[1:]):
@@ -543,7 +548,7 @@ def _reshape_to_n_sample_2d(arr: np.ndarray, n_sample: int = 60) -> np.ndarray:
 def get_binned_drops_from_event_perigee(
     ep: EventPerigee,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Get the number of kalman drops per "minute" from NPNT telemetry.
+    """Get the fraction of IR flags per "minute" from NPNT telemetry.
 
     Here a "minute" is really 60 * 1.025 seconds = 61.5, or 1.025 minutes. This
     corresponds to exactly 30 ACA image readouts (2.05 sec per image) per "minute".
@@ -557,8 +562,8 @@ def get_binned_drops_from_event_perigee(
     -------
     time_means : np.ndarray
         Array of mean time from perigee (sec) in each bin
-    n_lost_sums : np.ndarray
-        Array of total number of kalman drops in each bin
+    ir_flag_fracs : np.ndarray
+        Array of fraction of IR flags set in each bin
     """
     # Select only data in AOPCADMD in NPNT and AOACASEQ in KALM
     npnt_kalm = ep.data["npnt_kalm"]
@@ -637,7 +642,7 @@ def get_perigee_events(
 
 
 def get_kalman_drops_npnt(start, stop, duration=100) -> KalmanDropsData:
-    """Get the number of kalman drops per minute from NPNT telemetry.
+    """Get the fraction of IR flags set per minute from NPNT telemetry.
 
     Parameters
     ----------
@@ -683,7 +688,7 @@ def plot_kalman_drops(
     title: str | None = None,
     marker_size: float = 10,
 ) -> matplotlib.collections.PathCollection:
-    """Plot the number of kalman drops per minute.
+    """Plot the fraction of IR flags set per minute.
 
     Parameters
     ----------
@@ -725,7 +730,7 @@ def plot_kalman_drops(
 def plot_mon_win_and_aokalstr_composite(
     kalman_drops_npnt, kalman_drops_nman_list, outfile=None, title=""
 ):
-    """Plot the monitor window and kalman drops data.
+    """Plot the monitor window (NMAN) and NPNT IR flags fraction data.
 
     Parameters
     ----------

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -819,7 +819,7 @@ def main(args=None):
     kalman_drops_npnt = get_kalman_drops_npnt(start, stop)
 
     outfile = Path(opt.data_dir) / f"mon_win_kalman_drops_{opt.start}_{opt.stop}.png"
-    title = f"Perigee Kalman drops per minute {start.date[:8]} to {stop.date[:8]}"
+    title = f"IR flag fraction {start.date[:8]} to {stop.date[:8]}"
     plot_mon_win_and_aokalstr_composite(
         kalman_drops_npnt, kalman_drops_nman_list, outfile=outfile, title=title
     )


### PR DESCRIPTION
## Description

`monitor_win_perigee.py` is the trending code that makes the composite plot reflecting ionizing radiation near perigee using  ACA / OBC telemetry in NPNT and ACA monitor window image data in NMAN. 

Previously the code was taking a short-cut and using `8 - AOKALSTR` as a proxy for the count of IR flags, but this is distorted by times when a slot is not tracked and can also reflect other flags or problems.

Instead the new code directly counts the IR flags in telemetry to give an apples-to-apples comparison between NPNT and NMAN data. In addition the code is more careful now about normalization and the quantity that gets plotted is the fraction of available images that have the IR flag set. In the case of NPNT this requires both `AOACASEQ == "KALM"` and that the image tracking flag is set.

An unrelated change was just tidying a few style issue that `ruff` highlighted in `kalman_perigee_mon.py`. There is one slightly non-trivial change using `lines.extend`. I wasn't 100% sure of this behavior but it works and I did functional testing:
```
In [2]: a = [10]
In [3]: a.extend(x for x in range(5))
In [4]: a
Out[4]: [10, 0, 1, 2, 3, 4]
```
## Functional testing

### `monitor_win_perigee.py`

Ran the following from with the repo in Ska3:
```
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2023:290 --stop 2023:325
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2023:320 --stop 2023:355
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2023:350 --stop 2024:005
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2024:001 --stop 2024:035
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2024:030 --stop 2024:065
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2024:060 --stop 2024:095
python -m kalman_watch.monitor_win_perigee --n-cache 300 --start 2024:090 --stop 2024:115
```
This gave the expected results for instance:
![image](https://github.com/sot/kalman_watch/assets/348089/9c5704cc-88ac-4ed2-b5d4-26e3dffbf632)

### `kalman_perigee_mon.py`

Expected outputs:
```
(ska3) ➜  kalman_watch git:(use-ir-flag-in-mon-win-perigee) python -m kalman_watch.kalman_perigee_mon --stop 2022:165 --email=TEST --data-dir=play
Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.
Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.
2024-04-29 06:38:24,869 log_run_info: ******************************************
2024-04-29 06:38:24,869 log_run_info: Running: /Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py
2024-04-29 06:38:24,869 log_run_info: Version: 0.3.1.dev3+g0da5648
2024-04-29 06:38:24,869 log_run_info: Time: Mon Apr 29 06:38:24 2024
2024-04-29 06:38:24,869 log_run_info: User: root
2024-04-29 06:38:24,869 log_run_info: Machine: saos-MBP
2024-04-29 06:38:24,869 log_run_info: Processing args:
2024-04-29 06:38:24,869 log_run_info: {'data_dir': 'play',
2024-04-29 06:38:24,869 log_run_info:  'emails': ['TEST'],
2024-04-29 06:38:24,869 log_run_info:  'lookback': 14,
2024-04-29 06:38:24,869 log_run_info:  'make_html': False,
2024-04-29 06:38:24,869 log_run_info:  'stop': '2022:165'}
2024-04-29 06:38:24,869 log_run_info: ******************************************
2024-04-29 06:38:24,870 read_kalman_stats: No kalman perigee stats data found at play/perigees/kalman_perigees.ecsv
2024-04-29 06:38:24,870 read_kalman_stats: Creating new table from 0 info files
2024-04-29 06:38:24,870 get_evts_perigee: Getting perigee events between 2022:151:00:00:00.000 and 2022:165:00:00:00.000
2024-04-29 06:38:25,218 _get_tlm: Getting telemetry for 2022:152:04:14:24.365
2024-04-29 06:38:25,415 _get_tlm: Getting telemetry for 2022:154:19:43:59.552
2024-04-29 06:38:25,553 _get_tlm: Getting telemetry for 2022:157:11:13:15.204
2024-04-29 06:38:25,693 _get_tlm: Getting telemetry for 2022:160:02:41:36.780
2024-04-29 06:38:25,833 _get_tlm: Getting telemetry for 2022:162:18:09:01.633
2024-04-29 06:38:25,971 get_evts_perigee: Found 5 new perigee event(s)
2024-04-29 06:38:25,972 obss: Getting observations from kadi commands for 2022/Jun-01
2024-04-29 06:38:28,489 write_data: Writing perigee data to play/perigees/2022/Jun-01/data.npz
2024-04-29 06:38:28,493 write_info: Writing info to play/perigees/2022/Jun-01/info.json
2024-04-29 06:38:28,498 obss: Getting observations from kadi commands for 2022/Jun-03
2024-04-29 06:38:28,500 write_data: Writing perigee data to play/perigees/2022/Jun-03/data.npz
2024-04-29 06:38:28,503 write_info: Writing info to play/perigees/2022/Jun-03/info.json
2024-04-29 06:38:28,508 obss: Getting observations from kadi commands for 2022/Jun-06
2024-04-29 06:38:28,510 write_data: Writing perigee data to play/perigees/2022/Jun-06/data.npz
2024-04-29 06:38:28,513 write_info: Writing info to play/perigees/2022/Jun-06/info.json
2024-04-29 06:38:28,517 obss: Getting observations from kadi commands for 2022/Jun-09
2024-04-29 06:38:28,519 write_data: Writing perigee data to play/perigees/2022/Jun-09/data.npz
2024-04-29 06:38:28,523 write_info: Writing info to play/perigees/2022/Jun-09/info.json
2024-04-29 06:38:28,527 obss: Getting observations from kadi commands for 2022/Jun-11
2024-04-29 06:38:28,529 write_data: Writing perigee data to play/perigees/2022/Jun-11/data.npz
2024-04-29 06:38:28,532 write_info: Writing info to play/perigees/2022/Jun-11/info.json
2024-04-29 06:38:28,543 main: Writing perigee data play/perigees/kalman_perigees.ecsv
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: kalman_watch: long drop interval(s)
From: aldcroft@head.cfa.harvard.edu
To: TEST

******************************************
Running /Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py
acdc version: 4.13.2
Time: Mon Apr 29 06:38:28 2024
User: root
Machine: saos-MBP
Processing args:
{'data_dir': 'play',
 'emails': ['TEST'],
 'lookback': 14,
 'make_html': False,
 'stop': '2022:165'}
******************************************

Long drop interval(s) found for the following perigee events:
2022/Jun-11 2022:162:18:09:01.633
```

### Validation of IR fraction compared to Kalman drops

From https://gist.github.com/taldcroft/524136904910254ff3eed0bd224764b5 there is this plot:
<img width="935" alt="image" src="https://github.com/sot/kalman_watch/assets/348089/5d9adc99-05e3-4c23-8a0d-7ed70f86f93f">

From the new code for the same month of 2022-Jan we get:
![image](https://github.com/sot/kalman_watch/assets/348089/d451bb06-8aa6-47d4-b5c9-0de07eb9a0ef)

For an IR flag fraction of 0.1 we would expect the above plot to show about 48 Kalman drops / minute (0.1 * 8 * 60), but instead we see rates 2 to 3 times higher. The answer is that if you look at the raw data many/most of the Kalman drops come from a star being not tracked (the red X's below).

From https://cxc.cfa.harvard.edu/mta/ASPECT/kalman_watch3/perigees/2022/Jan-12/index.html there is this plot:
<img width="853" alt="image" src="https://github.com/sot/kalman_watch/assets/348089/3e66ce6d-eb0a-4bf2-acc9-abbdc5e819e1">

The new code only considers readouts when a star is being tracked and the IR flag *could* be set. So the two quantities are telling us different things:
- IR flag fraction: best estimate of actual radiation environment and best comparison to monitor window data
- Kalman drops: proxy for the overall impact of high radiation on star tracking and PCAD control
- 