### PR TITLE
Fix processing exceptions

### DIFF
--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -704,6 +704,9 @@ def get_kalman_drops_npnt(start, stop, duration=100) -> list[KalmanDropsData]:
 
     kalman_drops_list = []
     for ep in event_perigees:
+        if ep.tlm is None:
+            logger.warning(f"No telemetry for perigee {ep.perigee.date}")
+            continue
         if len(ep.data["times"]) > 200:
             times_from_perigee, n_drops = get_binned_drops_from_event_perigee(ep)
             kalman_drops = KalmanDropsData(

--- a/kalman_watch/monitor_win_perigee.py
+++ b/kalman_watch/monitor_win_perigee.py
@@ -402,10 +402,26 @@ def get_hits(
         }
         hits.append(hit)
 
-    hits = Table(hits)
-    hits["hit_idx"] = np.arange(len(hits))
+    if hits:
+        out = Table(hits)
+        out["hit_idx"] = np.arange(len(hits))
+    else:
+        out = Table(
+            names=[
+                "time",
+                "dt_min",
+                "slot",
+                "ir_flag",
+                "img_idx",
+                "sum",
+                "max",
+                "pixels",
+                "hit_idx",
+            ],
+            dtype=[float, float, int, bool, int, float, float, float, int],
+        )
 
-    return hits
+    return out
 
 
 def get_mon_dataset(


### PR DESCRIPTION
# Description

This fixes two issues in the `monitor_win_perigee` module:
- Returning an empty table of ionizing radiation `hits` (no columns) instead of a zero-length table with all the expected columns.
- Failing if there is insufficient telemetry covering a perigee within the processing date range.

## DO NOT MERGE

This is included in #14 because I could not test that one otherwise. Therefore this PR is purely for evaluation of the code and documenting the testing.

## Functional testing

### Base of this PR (no fixes)
```
(ska3) ➜  kalman_watch git:(fix-processing-exceptions) git checkout 5c4ed14 
HEAD is now at 5c4ed14 Refactor KalmanDropsData and add legend
(ska3) ➜  kalman_watch git:(5c4ed14) python -m kalman_watch.monitor_win_perigee --n-cache 300 --start=-10d >& 5c4ed14.log
(ska3) ➜  kalman_watch git:(5c4ed14) tail 5c4ed14.log 
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/monitor_win_perigee.py", line 509, in get_kalman_drops_per_minute
    ok = (mon["hits"]["dt_min"] >= dt_min0) & (mon["hits"]["dt_min"] < dt_min1)
          ~~~~~~~~~~~^^^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3/lib/python3.11/site-packages/astropy/table/table.py", line 2061, in __getitem__
    return self.columns[item]
           ~~~~~~~~~~~~^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3/lib/python3.11/site-packages/astropy/table/table.py", line 264, in __getitem__
    return OrderedDict.__getitem__(self, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'dt_min'
```

### Fix KeyError

This fixes the first issue but uncovers a second problem.
```
(ska3) ➜  kalman_watch git:(5c4ed14) git checkout 20634c3
HEAD is now at 20634c3 Define columns for zero-length hits table
(ska3) ➜  kalman_watch git:(20634c3) python -m kalman_watch.monitor_win_perigee --n-cache 300 --start=-10d >& 20634c3.log
(ska3) ➜  kalman_watch git:(20634c3) tail 20634c3.log                                                                    
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/monitor_win_perigee.py", line 707, in get_kalman_drops_npnt
    if len(ep.data["times"]) > 200:
           ^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 515, in data
    self._data = self._get_data()
                 ^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 528, in _get_data
    self.tlm[f"aoatter{axis}"].vals[::ATT_ERR_SUBSAMP].astype(np.float32)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```
### Fix NoneType problem
Success.
```
(ska3) ➜  kalman_watch git:(20634c3) git switch fix-processing-exceptions
Switched to branch 'fix-processing-exceptions'

(ska3) ➜  kalman_watch git:(fix-processing-exceptions) git rev-parse HEAD                                                   
3d2242ae7b5492acef2c552494f2f3103dc7a2bf
(
  ska3) ➜  kalman_watch git:(fix-processing-exceptions) python -m kalman_watch.monitor_win_perigee --n-cache 300 --start=-10d
2024-07-22 18:20:59,749 get_manvrs_perigee: Getting maneuvers from 2024:194:22:20:59.748 to 2024:203:22:20:59.749
2024-07-22 18:21:00,817 get_manvrs_perigee: Getting intervals of Earth blocks from 2024:194:22:20:59.748 to 2024:203:22:20:59.749
2024-07-22 18:21:01,189 get_manvrs_perigee:  Excluding Earth block from 2024:196:22:37:14.109 to 2024:196:23:07:43.734
2024-07-22 18:21:01,194 get_mon_dataset: Getting MON data from 2024:196:22:32:59.909 to 2024:196:22:37:14.109
2024-07-22 18:21:01,194 get_aca_images_cached: Getting ACA images from 2024:196:22:32:59.909 to 2024:196:22:37:14.109
2024-07-22 18:21:01,281 get_ir_thresholds: Getting IR thresholds from 2023:100 to 2023:200
2024-07-22 18:21:02,431 get_mon_dataset: Getting MON data from 2024:196:23:07:43.734 to 2024:196:23:25:55.359
2024-07-22 18:21:02,432 get_aca_images_cached: Getting ACA images from 2024:196:23:07:43.734 to 2024:196:23:25:55.359
2024-07-22 18:21:02,531 get_mon_dataset: Getting MON data from 2024:196:23:45:41.284 to 2024:197:00:10:12.159
2024-07-22 18:21:02,531 get_aca_images_cached: Getting ACA images from 2024:196:23:45:41.284 to 2024:197:00:10:12.159
2024-07-22 18:21:02,637 get_mon_dataset: Getting MON data from 2024:199:13:03:22.274 to 2024:199:13:41:55.699
2024-07-22 18:21:02,637 get_aca_images_cached: Getting ACA images from 2024:199:13:03:22.274 to 2024:199:13:41:55.699
2024-07-22 18:21:02,795 get_mon_dataset: Getting MON data from 2024:199:14:05:59.924 to 2024:199:14:53:56.074
2024-07-22 18:21:02,795 get_aca_images_cached: Getting ACA images from 2024:199:14:05:59.924 to 2024:199:14:53:56.074
2024-07-22 18:21:02,977 _get_tlm: Getting telemetry for 2024:196:22:49:48.288
2024-07-22 18:21:03,051 obss: Getting observations from kadi commands for 2024/Jul-14
2024-07-22 18:21:03,057 _get_tlm: Getting telemetry for 2024:199:14:17:25.860
2024-07-22 18:21:03,127 obss: Getting observations from kadi commands for 2024/Jul-17
2024-07-22 18:21:03,133 _get_tlm: Getting telemetry for 2024:202:05:45:08.820
2024-07-22 18:21:03,181 get_kalman_drops_npnt: No telemetry for perigee 2024:202:05:45:08.820
Perigee 2024:196:22:49:48.288 color C0
Perigee 2024:199:14:17:25.860 color C1
2024-07-22 18:21:03,287 clean_aca_images_cache: Cleaning ACA images cache to keep most recent 300 files
```
