### PR TITLE
Filter drops in NMAN list correctly

### DIFF
--- a/kalman_watch/kalman_perigee_mon.py
+++ b/kalman_watch/kalman_perigee_mon.py
@@ -20,10 +20,10 @@ from ska_helpers.run_info import log_run_info
 
 from kalman_watch import __version__, conf, paths
 from kalman_watch.kalman_watch_data import (
-    get_dirname,
     EventPerigee,
-    get_stats,
+    get_dirname,
     get_evts_perigee,
+    get_stats,
     read_kalman_stats,
 )
 

--- a/kalman_watch/kalman_watch_data.py
+++ b/kalman_watch/kalman_watch_data.py
@@ -1089,6 +1089,9 @@ def get_kalman_drops_nman(start, stop) -> list[KalmanDropsData]:
             # window data or not enough data to be useful. The previous behavior of not
             # applying this conditional resulted in crashes for a maneuver starting
             # around 2025:243:09:24:54.511.
+            LOGGER.info(
+                f"Skipping NMAN from {mon['start']} to {mon['stop']} due to "
+                "insufficient monitor window data within 100 minutes of perigee")
             continue
 
         kalman_drops_nman_list.append(

--- a/kalman_watch/kalman_watch_data.py
+++ b/kalman_watch/kalman_watch_data.py
@@ -892,9 +892,9 @@ def get_mon_dataset(
     Parameters
     ----------
     start : CxoTimeLike
-        Start time
+        Start time (typically for a particular maneuver within perigee)
     stop : CxoTimeLike
-        Stop time
+        Stop time (typically for a particular maneuver within perigee)
     ir_thresholds_start : CxoTimeLike
         Start time for sampling guide stars for IR thresholds
     ir_thresholds_stop : CxoTimeLike
@@ -1049,14 +1049,14 @@ def get_kalman_drops_nman(start, stop) -> list[KalmanDropsData]:
 
     Parameters
     ----------
-    mon : MonDataSet
-        Dataset of MON data from get_mon_dataset()
-    idx : int
-        Index of this perigee (used to assign a color)
+    start : CxoTimeLike
+        Start time (typically for a particular maneuver within perigee)
+    stop : CxoTimeLike
+        Stop time (typically for a particular maneuver within perigee)
 
     Returns
     -------
-    kalman_drops_data : KalmanDropsData
+    kalman_drops_data : list[KalmanDropsData]
     """
     manvrs_perigee = get_manvrs_perigee(start, stop)
 
@@ -1081,6 +1081,16 @@ def get_kalman_drops_nman(start, stop) -> list[KalmanDropsData]:
     kalman_drops_nman_list = []
     for mon in mons:
         dt_mins, kalman_drops_lst = get_kalman_drops_per_minute(mon)
+        if len(dt_mins) < 5:
+            # Require at least 5 "minutes" of data to be useful. This processing
+            # includes each maneuver in perigee that intersects with the -100 to +100
+            # minute interval around perigee. However the monitor window data does not
+            # cover the entire maneuver interval, so we may end up with no monitor
+            # window data or not enough data to be useful. The previous behavior of not
+            # applying this conditional resulted in crashes for a maneuver starting
+            # around 2025:243:09:24:54.511.
+            continue
+
         kalman_drops_nman_list.append(
             KalmanDropsData(
                 start=mon["start"],


### PR DESCRIPTION
## Description

This fixes a crash seen in daily processing for a maneuver on 2025:243 by requiring at least 5 "minutes" of data to be useful. 

This processing includes each maneuver in perigee that intersects with the -100 to +100 minute interval around perigee. However the monitor window data does not cover the entire maneuver interval, so we may end up with no monitor window data or not enough data to be useful within 100 minutes of perigee. The previous behavior of not applying this conditional resulted in crashes for a maneuver starting  around 2025:243:09:24:54.511.
```
python -m kalman_watch.kalman_perigee_mon --data-dir junk --make-html
2025-09-10 12:25:22,886 log_run_info: ******************************************
2025-09-10 12:25:22,886 log_run_info: Running: /Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py
2025-09-10 12:25:22,886 log_run_info: Version: 0.6.1.dev0+gb5f1178.d20250910
2025-09-10 12:25:22,886 log_run_info: Time: Wed Sep 10 12:25:22 2025
2025-09-10 12:25:22,887 log_run_info: User: root
2025-09-10 12:25:22,887 log_run_info: Machine: saos-MacBook-Pro.local
2025-09-10 12:25:22,887 log_run_info: Processing args:
2025-09-10 12:25:22,887 log_run_info: {'data_dir': PosixPath('junk'),
2025-09-10 12:25:22,887 log_run_info:  'emails': [],
2025-09-10 12:25:22,887 log_run_info:  'lookback': 14,
2025-09-10 12:25:22,887 log_run_info:  'make_html': True,
2025-09-10 12:25:22,887 log_run_info:  'rad_data': PosixPath('/Users/aldcroft/ska/data/stk/radiation_data.fits'),
2025-09-10 12:25:22,887 log_run_info:  'stop': None}
2025-09-10 12:25:22,887 log_run_info: ******************************************
2025-09-10 12:25:22,887 read_kalman_stats: Reading kalman perigee data from junk/perigees/kalman_perigees.ecsv
2025-09-10 12:25:22,889 get_evts_perigee: Getting perigee events between 2025:239:16:25:22.887 and 2025:253:16:25:22.887
2025-09-10 12:25:24,375 _get_tlm: Getting telemetry for 2025:251:09:57:21.199
2025-09-10 12:25:24,509 get_evts_perigee: Found 1 new perigee event(s)
2025-09-10 12:25:24,510 obss: Getting observations from kadi commands for 2025/Sep-08
2025-09-10 12:25:24,758 write_data: Writing perigee data to junk/perigees/2025/Sep-08/data.npz
2025-09-10 12:25:24,762 write_info: Writing info to junk/perigees/2025/Sep-08/info.json
2025-09-10 12:25:24,766 main: Writing perigee data junk/perigees/kalman_perigees.ecsv
2025-09-10 12:25:24,767 from_npz: Loading perigee event from junk/perigees/2025/Sep-08/data.npz
2025-09-10 12:25:25,290 get_manvrs_perigee: Getting maneuvers from 2025:251:04:24:01.199 to 2025:251:15:15:42.578
2025-09-10 12:25:25,297 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:251:04:24:01.199 to 2025:251:15:15:42.578
2025-09-10 12:25:25,341 get_mon_dataset: Getting MON data from 2025:251:08:19:25.592 to 2025:251:08:40:56.067
2025-09-10 12:25:25,341 get_aca_images_cached: Getting ACA images from 2025:251:08:19:25.592 to 2025:251:08:40:56.067
2025-09-10 12:25:25,496 get_ir_thresholds: Getting IR thresholds from 2023:100 to 2023:200
2025-09-10 12:25:25,989 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:25:25,995 _get_tlm: Getting telemetry for 2025:251:09:57:21.199
2025-09-10 12:25:26,168 make_detail_page: Writing perigee detail page to junk/perigees/2025/Sep-08/index.html
2025-09-10 12:25:26,169 from_npz: Loading perigee event from junk/perigees/2025/Sep-05/data.npz
2025-09-10 12:25:26,196 get_manvrs_perigee: Getting maneuvers from 2025:248:12:57:11.502 to 2025:248:23:25:25.821
2025-09-10 12:25:26,205 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:248:12:57:11.502 to 2025:248:23:25:25.821
2025-09-10 12:25:26,249 get_mon_dataset: Getting MON data from 2025:248:18:55:26.377 to 2025:248:19:25:56.003
2025-09-10 12:25:26,249 get_aca_images_cached: Getting ACA images from 2025:248:18:55:26.377 to 2025:248:19:25:56.003
2025-09-10 12:25:26,349 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:25:26,355 _get_tlm: Getting telemetry for 2025:248:18:30:31.502
2025-09-10 12:25:26,525 make_detail_page: Writing perigee detail page to junk/perigees/2025/Sep-05/index.html
2025-09-10 12:25:26,526 from_npz: Loading perigee event from junk/perigees/2025/Sep-03/data.npz
2025-09-10 12:25:26,554 get_manvrs_perigee: Getting maneuvers from 2025:246:01:22:06.697 to 2025:246:08:36:27.322
2025-09-10 12:25:26,563 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:246:01:22:06.697 to 2025:246:08:36:27.322
2025-09-10 12:25:26,599 get_manvrs_perigee:  Excluding Earth block from 2025:246:02:19:06.687 to 2025:246:03:04:31.137
2025-09-10 12:25:26,600 get_mon_dataset: Getting MON data from 2025:246:01:22:07.287 to 2025:246:01:55:55.762
2025-09-10 12:25:26,600 get_aca_images_cached: Getting ACA images from 2025:246:01:22:07.287 to 2025:246:01:55:55.762
2025-09-10 12:25:26,704 get_mon_dataset: Getting MON data from 2025:246:02:15:40.662 to 2025:246:02:19:06.687
2025-09-10 12:25:26,704 get_aca_images_cached: Getting ACA images from 2025:246:02:15:40.662 to 2025:246:02:19:06.687
2025-09-10 12:25:26,789 get_mon_dataset: Getting MON data from 2025:246:03:04:31.137 to 2025:246:03:05:46.987
2025-09-10 12:25:26,789 get_aca_images_cached: Getting ACA images from 2025:246:03:04:31.137 to 2025:246:03:05:46.987
2025-09-10 12:25:26,872 get_mon_dataset: Getting MON data from 2025:246:03:25:31.887 to 2025:246:03:56:02.537
2025-09-10 12:25:26,873 get_aca_images_cached: Getting ACA images from 2025:246:03:25:31.887 to 2025:246:03:56:02.537
2025-09-10 12:25:26,973 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:25:26,991 _get_tlm: Getting telemetry for 2025:246:03:03:07.322
2025-09-10 12:25:27,122 make_detail_page: Writing perigee detail page to junk/perigees/2025/Sep-03/index.html
2025-09-10 12:25:27,123 from_npz: Loading perigee event from junk/perigees/2025/Aug-31/data.npz
2025-09-10 12:25:27,149 get_manvrs_perigee: Getting maneuvers from 2025:243:06:02:02.122 to 2025:243:16:46:03.135
2025-09-10 12:25:27,158 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:243:06:02:02.122 to 2025:243:16:46:03.135
2025-09-10 12:25:27,202 get_mon_dataset: Getting MON data from 2025:243:09:22:11.872 to 2025:243:09:55:56.247
2025-09-10 12:25:27,202 get_aca_images_cached: Getting ACA images from 2025:243:09:22:11.872 to 2025:243:09:55:56.247
2025-09-10 12:25:27,304 get_mon_dataset: Getting MON data from 2025:243:12:44:09.422 to 2025:243:12:51:19.922
2025-09-10 12:25:27,304 get_aca_images_cached: Getting ACA images from 2025:243:12:44:09.422 to 2025:243:12:51:19.922
2025-09-10 12:25:27,317 get_mon_dataset: Not enough images for slot 0 found 0)
2025-09-10 12:25:27,318 get_mon_dataset: Not enough images for slot 1 found 0)
2025-09-10 12:25:27,319 get_mon_dataset: Not enough images for slot 2 found 0)
2025-09-10 12:25:27,319 get_mon_dataset: Not enough images for slot 3 found 0)
2025-09-10 12:25:27,320 get_mon_dataset: Not enough images for slot 4 found 0)
2025-09-10 12:25:27,320 get_mon_dataset: Not enough images for slot 5 found 0)
2025-09-10 12:25:27,320 get_mon_dataset: Not enough images for slot 6 found 0)
2025-09-10 12:25:27,321 get_mon_dataset: Not enough images for slot 7 found 0)
2025-09-10 12:25:27,321 get_kalman_drops_nman: processing NMAN data
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 489, in <module>
    main()
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 161, in main
    evt.make_detail_page()
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 300, in make_detail_page
    html = self.get_detail_html()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 272, in get_detail_html
    fig = self.get_plot_fig()
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 364, in get_plot_fig
    x=self.kalman_drops_nman["times"],
      ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_watch_data.py", line 457, in kalman_drops_nman
    self._kalman_drops_nman = self._get_kalman_drops_nman()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/git/kalman_watch/kalman_watch/kalman_watch_data.py", line 470, in _get_kalman_drops_nman
    nman_table = vstack(
                 ^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-aca/lib/python3.12/site-packages/astropy/table/operations.py", line 714, in vstack
    tables = _get_list_of_tables(tables)  # validates input
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-aca/lib/python3.12/site-packages/astropy/table/operations.py", line 62, in _get_list_of_tables
    raise ValueError("no values provided to stack.")
ValueError: no values provided to stack.
```

## Functional testing
On my Mac in the ska3-aca environment I ran this and there were no errors and all the plots looked as expected.
```
$ python -m kalman_watch.kalman_perigee_mon --make-html --data-dir test-perigee-mon
2025-09-10 12:42:50,362 log_run_info: ******************************************
2025-09-10 12:42:50,362 log_run_info: Running: /Users/aldcroft/git/kalman_watch/kalman_watch/kalman_perigee_mon.py
2025-09-10 12:42:50,362 log_run_info: Version: 0.6.1.dev3+g0514c10
2025-09-10 12:42:50,362 log_run_info: Time: Wed Sep 10 12:42:50 2025
2025-09-10 12:42:50,362 log_run_info: User: root
2025-09-10 12:42:50,362 log_run_info: Machine: saos-MacBook-Pro.local
2025-09-10 12:42:50,362 log_run_info: Processing args:
2025-09-10 12:42:50,362 log_run_info: {'data_dir': PosixPath('test-perigee-mon'),
2025-09-10 12:42:50,362 log_run_info:  'emails': [],
2025-09-10 12:42:50,362 log_run_info:  'lookback': 14,
2025-09-10 12:42:50,362 log_run_info:  'make_html': True,
2025-09-10 12:42:50,362 log_run_info:  'rad_data': PosixPath('/Users/aldcroft/ska/data/stk/radiation_data.fits'),
2025-09-10 12:42:50,362 log_run_info:  'stop': None}
2025-09-10 12:42:50,362 log_run_info: ******************************************
2025-09-10 12:42:50,363 read_kalman_stats: No kalman perigee stats data found at test-perigee-mon/perigees/kalman_perigees.ecsv
2025-09-10 12:42:50,363 read_kalman_stats: Creating new table from 0 info files
2025-09-10 12:42:50,363 get_evts_perigee: Getting perigee events between 2025:239:16:42:50.363 and 2025:253:16:42:50.363
2025-09-10 12:42:51,853 _get_tlm: Getting telemetry for 2025:240:20:07:48.252
2025-09-10 12:42:51,984 _get_tlm: Getting telemetry for 2025:243:11:35:22.122
2025-09-10 12:42:52,112 _get_tlm: Getting telemetry for 2025:246:03:03:07.322
2025-09-10 12:42:52,213 _get_tlm: Getting telemetry for 2025:248:18:30:31.502
2025-09-10 12:42:52,334 _get_tlm: Getting telemetry for 2025:251:09:57:21.199
2025-09-10 12:42:52,455 get_evts_perigee: Found 5 new perigee event(s)
2025-09-10 12:42:52,455 obss: Getting observations from kadi commands for 2025/Aug-28
2025-09-10 12:42:52,691 write_data: Writing perigee data to test-perigee-mon/perigees/2025/Aug-28/data.npz
2025-09-10 12:42:52,695 write_info: Writing info to test-perigee-mon/perigees/2025/Aug-28/info.json
2025-09-10 12:42:52,698 obss: Getting observations from kadi commands for 2025/Aug-31
2025-09-10 12:42:52,699 write_data: Writing perigee data to test-perigee-mon/perigees/2025/Aug-31/data.npz
2025-09-10 12:42:52,703 write_info: Writing info to test-perigee-mon/perigees/2025/Aug-31/info.json
2025-09-10 12:42:52,706 obss: Getting observations from kadi commands for 2025/Sep-03
2025-09-10 12:42:52,708 write_data: Writing perigee data to test-perigee-mon/perigees/2025/Sep-03/data.npz
2025-09-10 12:42:52,710 write_info: Writing info to test-perigee-mon/perigees/2025/Sep-03/info.json
2025-09-10 12:42:52,714 obss: Getting observations from kadi commands for 2025/Sep-05
2025-09-10 12:42:52,715 write_data: Writing perigee data to test-perigee-mon/perigees/2025/Sep-05/data.npz
2025-09-10 12:42:52,718 write_info: Writing info to test-perigee-mon/perigees/2025/Sep-05/info.json
2025-09-10 12:42:52,721 obss: Getting observations from kadi commands for 2025/Sep-08
2025-09-10 12:42:52,723 write_data: Writing perigee data to test-perigee-mon/perigees/2025/Sep-08/data.npz
2025-09-10 12:42:52,726 write_info: Writing info to test-perigee-mon/perigees/2025/Sep-08/info.json
2025-09-10 12:42:52,731 main: Writing perigee data test-perigee-mon/perigees/kalman_perigees.ecsv
2025-09-10 12:42:52,735 from_npz: Loading perigee event from test-perigee-mon/perigees/2025/Sep-08/data.npz
2025-09-10 12:42:53,229 get_manvrs_perigee: Getting maneuvers from 2025:251:04:24:01.199 to 2025:251:15:15:42.578
2025-09-10 12:42:53,236 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:251:04:24:01.199 to 2025:251:15:15:42.578
2025-09-10 12:42:53,278 get_mon_dataset: Getting MON data from 2025:251:08:19:25.592 to 2025:251:08:40:56.067
2025-09-10 12:42:53,278 get_aca_images_cached: Getting ACA images from 2025:251:08:19:25.592 to 2025:251:08:40:56.067
2025-09-10 12:42:56,460 get_ir_thresholds: Getting IR thresholds from 2023:100 to 2023:200
2025-09-10 12:42:56,952 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:42:56,957 _get_tlm: Getting telemetry for 2025:251:09:57:21.199
2025-09-10 12:42:57,132 make_detail_page: Writing perigee detail page to test-perigee-mon/perigees/2025/Sep-08/index.html
2025-09-10 12:42:57,133 from_npz: Loading perigee event from test-perigee-mon/perigees/2025/Sep-05/data.npz
2025-09-10 12:42:57,160 get_manvrs_perigee: Getting maneuvers from 2025:248:12:57:11.502 to 2025:248:23:25:25.821
2025-09-10 12:42:57,169 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:248:12:57:11.502 to 2025:248:23:25:25.821
2025-09-10 12:42:57,214 get_mon_dataset: Getting MON data from 2025:248:18:55:26.377 to 2025:248:19:25:56.003
2025-09-10 12:42:57,214 get_aca_images_cached: Getting ACA images from 2025:248:18:55:26.377 to 2025:248:19:25:56.003
2025-09-10 12:43:01,582 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:43:01,588 _get_tlm: Getting telemetry for 2025:248:18:30:31.502
2025-09-10 12:43:01,758 make_detail_page: Writing perigee detail page to test-perigee-mon/perigees/2025/Sep-05/index.html
2025-09-10 12:43:01,759 from_npz: Loading perigee event from test-perigee-mon/perigees/2025/Sep-03/data.npz
2025-09-10 12:43:01,789 get_manvrs_perigee: Getting maneuvers from 2025:246:01:22:06.697 to 2025:246:08:36:27.322
2025-09-10 12:43:01,797 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:246:01:22:06.697 to 2025:246:08:36:27.322
2025-09-10 12:43:01,835 get_manvrs_perigee:  Excluding Earth block from 2025:246:02:19:06.687 to 2025:246:03:04:31.137
2025-09-10 12:43:01,836 get_mon_dataset: Getting MON data from 2025:246:01:22:07.287 to 2025:246:01:55:55.762
2025-09-10 12:43:01,836 get_aca_images_cached: Getting ACA images from 2025:246:01:22:07.287 to 2025:246:01:55:55.762
2025-09-10 12:43:06,596 get_mon_dataset: Getting MON data from 2025:246:02:15:40.662 to 2025:246:02:19:06.687
2025-09-10 12:43:06,596 get_aca_images_cached: Getting ACA images from 2025:246:02:15:40.662 to 2025:246:02:19:06.687
2025-09-10 12:43:07,189 get_mon_dataset: Getting MON data from 2025:246:03:04:31.137 to 2025:246:03:05:46.987
2025-09-10 12:43:07,189 get_aca_images_cached: Getting ACA images from 2025:246:03:04:31.137 to 2025:246:03:05:46.987
2025-09-10 12:43:07,535 get_mon_dataset: Getting MON data from 2025:246:03:25:31.887 to 2025:246:03:56:02.537
2025-09-10 12:43:07,535 get_aca_images_cached: Getting ACA images from 2025:246:03:25:31.887 to 2025:246:03:56:02.537
2025-09-10 12:43:11,891 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:43:11,899 get_kalman_drops_nman: Skipping NMAN from 2025:246:02:15:40.662 to 2025:246:02:19:06.687 due to insufficient monitor window data within 100 minutes of perigee
2025-09-10 12:43:11,902 get_kalman_drops_nman: Skipping NMAN from 2025:246:03:04:31.137 to 2025:246:03:05:46.987 due to insufficient monitor window data within 100 minutes of perigee
2025-09-10 12:43:11,909 _get_tlm: Getting telemetry for 2025:246:03:03:07.322
2025-09-10 12:43:12,043 make_detail_page: Writing perigee detail page to test-perigee-mon/perigees/2025/Sep-03/index.html
2025-09-10 12:43:12,044 from_npz: Loading perigee event from test-perigee-mon/perigees/2025/Aug-31/data.npz
2025-09-10 12:43:12,071 get_manvrs_perigee: Getting maneuvers from 2025:243:06:02:02.122 to 2025:243:16:46:03.135
2025-09-10 12:43:12,080 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:243:06:02:02.122 to 2025:243:16:46:03.135
2025-09-10 12:43:12,128 get_mon_dataset: Getting MON data from 2025:243:09:22:11.872 to 2025:243:09:55:56.247
2025-09-10 12:43:12,128 get_aca_images_cached: Getting ACA images from 2025:243:09:22:11.872 to 2025:243:09:55:56.247
2025-09-10 12:43:17,103 get_mon_dataset: Getting MON data from 2025:243:12:44:09.422 to 2025:243:12:51:19.922
2025-09-10 12:43:17,103 get_aca_images_cached: Getting ACA images from 2025:243:12:44:09.422 to 2025:243:12:51:19.922
2025-09-10 12:43:18,417 get_mon_dataset: Not enough images for slot 0 found 0)
2025-09-10 12:43:18,418 get_mon_dataset: Not enough images for slot 1 found 0)
2025-09-10 12:43:18,418 get_mon_dataset: Not enough images for slot 2 found 0)
2025-09-10 12:43:18,419 get_mon_dataset: Not enough images for slot 3 found 0)
2025-09-10 12:43:18,419 get_mon_dataset: Not enough images for slot 4 found 0)
2025-09-10 12:43:18,420 get_mon_dataset: Not enough images for slot 5 found 0)
2025-09-10 12:43:18,420 get_mon_dataset: Not enough images for slot 6 found 0)
2025-09-10 12:43:18,421 get_mon_dataset: Not enough images for slot 7 found 0)
2025-09-10 12:43:18,421 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:43:18,424 get_kalman_drops_nman: Skipping NMAN from 2025:243:09:22:11.872 to 2025:243:09:55:56.247 due to insufficient monitor window data within 100 minutes of perigee
2025-09-10 12:43:18,425 _get_tlm: Getting telemetry for 2025:243:11:35:22.122
2025-09-10 12:43:18,601 make_detail_page: Writing perigee detail page to test-perigee-mon/perigees/2025/Aug-31/index.html
2025-09-10 12:43:18,602 from_npz: Loading perigee event from test-perigee-mon/perigees/2025/Aug-28/data.npz
2025-09-10 12:43:18,631 get_manvrs_perigee: Getting maneuvers from 2025:240:14:34:28.252 to 2025:241:01:06:22.861
2025-09-10 12:43:18,640 get_manvrs_perigee: Getting intervals of Earth blocks from 2025:240:14:34:28.252 to 2025:241:01:06:22.861
2025-09-10 12:43:18,685 get_kalman_drops_nman: processing NMAN data
2025-09-10 12:43:18,685 _get_tlm: Getting telemetry for 2025:240:20:07:48.252
2025-09-10 12:43:18,853 make_detail_page: Writing perigee detail page to test-perigee-mon/perigees/2025/Aug-28/index.html
2025-09-10 12:43:18,856 make_index_list_pages: Writing recent index list page to test-perigee-mon/perigees/index.html
2025-09-10 12:43:18,859 make_index_list_pages: Writing index list page for 2025 to test-perigee-mon/perigees/2025/index.html
```
