### PR TITLE
Add custom json encoder for numpy 2 behavior

### DIFF
--- a/kalman_watch/kalman_watch_data.py
+++ b/kalman_watch/kalman_watch_data.py
@@ -53,6 +53,17 @@ KALMAN_LIMITS = [
 ]
 
 
+# Custom JSON encoder to handle numpy types
+class InfoEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        elif isinstance(obj, (np.integer, np.floating)):
+            return obj.item()
+        else:
+            return super().default(obj)
+
+
 def get_dirname(date: Union[CxoTime, None]) -> str:
     if date is None:
         out = ""
@@ -368,7 +379,7 @@ class EventPerigee:
         """Write info to file"""
         path = self.info_path
         LOGGER.info(f"Writing info to {path}")
-        path.write_text(json.dumps(self.info, indent=4))
+        path.write_text(json.dumps(self.info, indent=4, cls=InfoEncoder))
 
     def write_data(self):
         # Compressed version of data


### PR DESCRIPTION
Add custom json encoder for numpy 2 behavior.

Fixes: 
```
Traceback (most recent call last):
  File "/Users/jean/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 489, in <module>
    main()
    ~~~~^^
  File "/Users/jean/git/kalman_watch/kalman_watch/kalman_perigee_mon.py", line 126, in main
    evt_perigee.write_info()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jean/git/kalman_watch/kalman_watch/kalman_watch_data.py", line 371, in write_info
    path.write_text(json.dumps(self.info, indent=4))
                    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.1rc5/lib/python3.13/json/__init__.py", line 242, in dumps
    **kw).encode(obj)
          ~~~~~~^^^^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.1rc5/lib/python3.13/json/encoder.py", line 202, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.1rc5/lib/python3.13/json/encoder.py", line 263, in iterencode
    return _iterencode(o, 0)
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.1rc5/lib/python3.13/json/encoder.py", line 182, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
                    f'is not JSON serializable')
TypeError: Object of type int64 is not JSON serializable
```
with recent numpy

 - [x] No unit testing

I ran this code from python kalman_watch/kalman_perigee_mon.py (which calls this) and compared one info.json file from the numpy 1.26.4 version and the new output with this patch on numpy 2.x and the files were the same.